### PR TITLE
GET /api/v1/olympians

### DIFF
--- a/lib/koroibos_web/controllers/fallback_controller.ex
+++ b/lib/koroibos_web/controllers/fallback_controller.ex
@@ -1,0 +1,22 @@
+defmodule KoroibosWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use KoroibosWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(KoroibosWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(KoroibosWeb.ErrorView)
+    |> render(:"404")
+  end
+end

--- a/lib/koroibos_web/controllers/v1/olympians_controller.ex
+++ b/lib/koroibos_web/controllers/v1/olympians_controller.ex
@@ -1,0 +1,7 @@
+defmodule KoroibosWeb.OlympianController do
+  use KoroibosWeb, :controller
+
+  def index(conn, _params) do
+    render(conn, "index.json")
+  end
+end

--- a/lib/koroibos_web/controllers/v1/olympians_controller.ex
+++ b/lib/koroibos_web/controllers/v1/olympians_controller.ex
@@ -1,7 +1,8 @@
 defmodule KoroibosWeb.OlympianController do
   use KoroibosWeb, :controller
+  alias Koroibos.Olympian
 
   def index(conn, _params) do
-    render(conn, "index.json")
+    render(conn, "index.json", olympians: Olympian.index)
   end
 end

--- a/lib/koroibos_web/router.ex
+++ b/lib/koroibos_web/router.ex
@@ -5,7 +5,9 @@ defmodule KoroibosWeb.Router do
     plug :accepts, ["json"]
   end
 
-  scope "/api", KoroibosWeb do
+  scope "/api/v1", KoroibosWeb do
     pipe_through :api
+
+    get "/olympians", OlympianController, :index
   end
 end

--- a/lib/koroibos_web/views/changeset_view.ex
+++ b/lib/koroibos_web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule KoroibosWeb.ChangesetView do
+  use KoroibosWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `KoroibosWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/lib/koroibos_web/views/v1/olympian_view.ex
+++ b/lib/koroibos_web/views/v1/olympian_view.ex
@@ -1,0 +1,12 @@
+defmodule KoroibosWeb.OlympianView do
+  use KoroibosWeb, :view
+  alias KoroibosWeb.OlympianView
+
+  def render("index.json", %{olympians: olympians}) do
+    %{olympians: render_many(olympians, OlympianView, "olympian.json")}
+  end
+
+  def render("olympian.json", %{olympian: olympian}) do
+    %{name: olympian.name, team: olympian.team, age: olympian.age}
+  end
+end

--- a/lib/koroibos_web/views/v1/olympian_view.ex
+++ b/lib/koroibos_web/views/v1/olympian_view.ex
@@ -7,6 +7,12 @@ defmodule KoroibosWeb.OlympianView do
   end
 
   def render("olympian.json", %{olympian: olympian}) do
-    %{name: olympian.name, team: olympian.team, age: olympian.age}
+    %{
+      name: olympian.name,
+      team: olympian.team,
+      age: olympian.age,
+      sport: olympian.sport,
+      total_medals_won: olympian.total_medals_won
+    }
   end
 end

--- a/test/controllers/api/v1/olympians_controller_test.exs
+++ b/test/controllers/api/v1/olympians_controller_test.exs
@@ -1,11 +1,12 @@
 defmodule Koroibos.OlympiansControllerTest do
   use KoroibosWeb.ConnCase
   # use Koroibos.DataCase
-  alias Koroibos.{Olympian, Team}
+  alias Koroibos.{Team, Olympian, Sport, Event, Result}
 
   test "#index renders a list of todos" do
     conn = build_conn()
     {:ok, %Team{} = team} = Team.create(%{name: "Team Name"})
+
     {:ok, %Olympian{} = olympian_1} = Olympian.create(
       %{team_id: team.id, name: "Olympian Name 1", sex: "M", age: 1, height: 100, weight: 200}
     )
@@ -13,22 +14,35 @@ defmodule Koroibos.OlympiansControllerTest do
       %{team_id: team.id, name: "Olympian Name 2", sex: "M", age: 1, height: 100, weight: 200}
     )
 
+    {:ok, %Sport{} = sport} = Sport.create(%{description: "Basketball"})
+
+    {:ok, %Event{} = event} = Event.create(%{sport_id: sport.id, name: "Basketball - Mens 5x5"})
+
+    Result.create(%{olympian_id: olympian_1.id,
+                    event_id: event.id,
+                    event_year: "2016 Summer",
+                    medal: "Gold"})
+    Result.create(%{olympian_id: olympian_2.id,
+                    event_id: event.id,
+                    event_year: "2016 Summer",
+                    medal: "NA"})
+
     conn = get conn, "/api/v1/olympians"
 
     expected = %{
         "olympians" => [
           %{ "name" => olympian_1.name,
-             "team" => olympian_1.team,
+             "team" => team.name,
              "age" => olympian_1.age,
-             "sport" => olympian_1.sport,
-             "total_medals_won" => olympian_1.total_medals_won
+             "sport" => sport.description,
+             "total_medals_won" => 1,
            },
-          %{ "name" => olympian_2.name,
-             "team" => olympian_2.team,
-             "age" => olympian_2.age,
-             "sport" => olympian_2.sport,
-             "total_medals_won" => olympian_2.total_medals_won
-           }
+           %{ "name" => olympian_2.name,
+              "team" => team.name,
+              "age" => olympian_2.age,
+              "sport" => sport.description,
+              "total_medals_won" => 0,
+            }
         ]
       }
 

--- a/test/controllers/api/v1/olympians_controller_test.exs
+++ b/test/controllers/api/v1/olympians_controller_test.exs
@@ -1,0 +1,37 @@
+defmodule Koroibos.OlympiansControllerTest do
+  use KoroibosWeb.ConnCase
+  # use Koroibos.DataCase
+  alias Koroibos.{Olympian, Team}
+
+  test "#index renders a list of todos" do
+    conn = build_conn()
+    {:ok, %Team{} = team} = Team.create(%{name: "Team Name"})
+    {:ok, %Olympian{} = olympian_1} = Olympian.create(
+      %{team_id: team.id, name: "Olympian Name 1", sex: "M", age: 1, height: 100, weight: 200}
+    )
+    {:ok, %Olympian{} = olympian_2} = Olympian.create(
+      %{team_id: team.id, name: "Olympian Name 2", sex: "M", age: 1, height: 100, weight: 200}
+    )
+
+    conn = get conn, "/api/v1/olympians"
+
+    expected = %{
+        "olympians" => [
+          %{ "name" => olympian_1.name,
+             "team" => olympian_1.team,
+             "age" => olympian_1.age,
+             "sport" => olympian_1.sport,
+             "total_medals_won" => olympian_1.total_medals_won
+           },
+          %{ "name" => olympian_2.name,
+             "team" => olympian_2.team,
+             "age" => olympian_2.age,
+             "sport" => olympian_2.sport,
+             "total_medals_won" => olympian_2.total_medals_won
+           }
+        ]
+      }
+
+    assert json_response(conn, 200) == expected
+  end
+end


### PR DESCRIPTION
## What functionality does this accomplish?
closes #5 

**Description:**
Adds  `GET api/v1/olympians`

- Attempted to complete this without using any generators to learn about each files functionality

```javascript
//Response Format
{
  "olympians":
    [
      {
        "name": "Maha Abdalsalam",
        "team": "Egypt",
        "age": 18,
        "sport": "Diving"
        "total_medals_won": 0
      },
      {
        "name": "Ahmad Abughaush",
        "team": "Jordan",
        "age": 20,
        "sport": "Taekwondo"
        "total_medals_won": 1
      },
      {...}
    ]
}
```

## Helpful Resources:
* Resource link AND small description of info gathered/learned
https://devhints.io/phoenix-ecto
https://hexdocs.pm/ecto/Ecto.Query.html
https://becoming-functional.com/building-a-rest-api-with-phoenix-1-3-part-1-9f8754aeaa87

## Please include an emoji of how you feel about this branch:
 🐝